### PR TITLE
Provide non-null value for Heating Threshold Temperature Characteristic

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,7 @@ TerneoHeatfloor.prototype = {
                 if (typeof lastState['target_temperature'] !== 'undefined') {
                     callback(null, lastState['target_temperature']);
                 } else {
-                    callback(null, null);
+                    callback(null, 0);
                 }
             })
             .on('set', (value, callback) => {


### PR DESCRIPTION
Fixes the following error:
`This plugin generated a warning from the characteristic 'Heating Threshold Temperature': characteristic was supplied illegal value: null! Home App will reject null for Apple defined characteristics. See https://git.io/JtMGR for more info.`

Otherwise all Homebridge accessories become unresponsive in HomeKit.